### PR TITLE
Apply modifications of SE-0235

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,35 +2,29 @@
 
 [![Build Status](https://travis-ci.org/koher/SwiftResult.svg?branch=master)](https://travis-ci.org/koher/SwiftResult)
 
-_SwiftResult_ provides a `Result` type which is compatible with the `Result` type proposed in [SE-0235](https://github.com/apple/swift-evolution/blob/master/proposals/0235-add-result.md), which may be added to the Swift standard library in Swift 5.x. Replacing third-party `Result` types with it may make it easier to migrate your code to Swift 5.x.
+_SwiftResult_ provides a `Result` type which is compatible with the `Result` type proposed in [SE-0235](https://github.com/apple/swift-evolution/blob/master/proposals/0235-add-result.md) ([announcement about modifications](https://forums.swift.org/t/accepted-with-modifications-se-0235-add-result-to-the-standard-library/18603)), which may be added to the Swift standard library in Swift 5.x. Replacing third-party `Result` types with it may make it easier to migrate your code to Swift 5.x.
 
 ```swift
 // An overload to return a `Result` instead of `throws`
 extension JSONDecoder {
-    func decode<T: Decodable>(_ type: T.Type, from data: Data) -> Result<T, DecodingError> {
+    func decode<T: Decodable>(_ type: T.Type, from json: JSON) -> Result<T, DecodingError> {
         ...
     }
 }
 
-let json = """
-{
-    "firstName": "Albert",
-    "lastName": "Einstein",
-    "age": 28
-}
-"""
+let json: JSON = ...
 
-let person: Result<Person, DecodingError> = JSONDecoder().decode(Person.self, from: json.data(using: .utf8)!)
+let person: Result<Person, DecodingError> = JSONDecoder().decode(Person.self, from: json)
 
 switch person {
-case .value(let person):
+case .success(let person):
     ... // Success
-case .error(let error):
+case .failure(_):
     ... // Failure
 }
 
 let age: Result<Int, DecodingError> = person.map { $0.age }
-try! age.unwrapped() // 28
+try! age.get() // 28
 ```
 
 ## Installation
@@ -42,14 +36,14 @@ Add the following to `dependencies` in your _Package.swift_.
 ```swift
 .package(
     url: "https://github.com/koher/SwiftResult.git",
-    from: "0.1.0"
+    from: "0.2.0"
 )
 ```
 
 ### Carthage
 
 ```
-github "koher/SwiftResult" ~> 0.1.0
+github "koher/SwiftResult" ~> 0.2.0
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ let person: Result<Person, DecodingError> = JSONDecoder().decode(Person.self, fr
 switch person {
 case .value(let person):
     ... // Success
-case .error(_):
+case .error(let error):
     ... // Failure
 }
 

--- a/Sources/SwiftResult/Result.swift
+++ b/Sources/SwiftResult/Result.swift
@@ -1,11 +1,11 @@
 /// A value that represents either a success or failure, capturing associated
 /// values in both cases.
-public enum Result<Value, Error/*: Swift.Error*/> {
+public enum Result<Success, Failure/*: Error*/> {
     /// A normal result, storing a `Value`.
-    case value(Value)
+    case success(Success)
     
     /// An error result, storing an `Error`.
-    case error(Error)
+    case failure(Failure)
     
     /// Evaluates the given transform closure when this `Result` instance is
     /// `.success`, passing the value as a parameter.
@@ -17,13 +17,13 @@ public enum Result<Value, Error/*: Swift.Error*/> {
     /// - Returns: A new `Result` instance with the result of the transform, if
     ///   it was applied.
     public func map<NewValue>(
-        _ transform: (Value) -> NewValue
-    ) -> Result<NewValue, Error> {
+        _ transform: (Success) -> NewValue
+    ) -> Result<NewValue, Failure> {
         switch self {
-        case .value(let value):
-            return .value(transform(value))
-        case .error(let error):
-            return .error(error)
+        case .success(let value):
+            return .success(transform(value))
+        case .failure(let error):
+            return .failure(error)
         }
     }
     
@@ -38,13 +38,13 @@ public enum Result<Value, Error/*: Swift.Error*/> {
     /// - Returns: A new `Result` instance with the result of the transform, if
     ///   it was applied.
     public func mapError<NewError>(
-        _ transform: (Error) -> NewError
-    ) -> Result<Value, NewError> {
+        _ transform: (Failure) -> NewError
+    ) -> Result<Success, NewError> {
         switch self {
-        case .value(let value):
-            return .value(value)
-        case .error(let error):
-            return .error(transform(error))
+        case .success(let value):
+            return .success(value)
+        case .failure(let error):
+            return .failure(transform(error))
         }
     }
     
@@ -56,13 +56,13 @@ public enum Result<Value, Error/*: Swift.Error*/> {
     /// - Returns: A new `Result` instance, either from the transform or from
     ///   the previous error value.
     public func flatMap<NewValue>(
-        _ transform: (Value) -> Result<NewValue, Error>
-    ) -> Result<NewValue, Error> {
+        _ transform: (Success) -> Result<NewValue, Failure>
+    ) -> Result<NewValue, Failure> {
         switch self {
-        case .value(let value):
+        case .success(let value):
             return transform(value)
-        case .error(let error):
-            return .error(error)
+        case .failure(let error):
+            return .failure(error)
         }
     }
     
@@ -74,46 +74,46 @@ public enum Result<Value, Error/*: Swift.Error*/> {
     /// - Returns: A new `Result` instance, either from the transform or from
     ///   the previous success value.
     public func flatMapError<NewError>(
-        _ transform: (Error) -> Result<Value, NewError>
-    ) -> Result<Value, NewError> {
+        _ transform: (Failure) -> Result<Success, NewError>
+    ) -> Result<Success, NewError> {
         switch self {
-        case .value(let value):
-            return .value(value)
-        case .error(let error):
+        case .success(let value):
+            return .success(value)
+        case .failure(let error):
             return transform(error)
         }
     }
 }
 
-extension Result where Error: Swift.Error {
+extension Result where Failure: Error {
     /// Unwraps the `Result` into a throwing expression.
     ///
     /// - Returns: The success value, if the instance is a success.
     /// - Throws:  The error value, if the instance is a failure.
-    public func unwrapped() throws -> Value {
+    public func get() throws -> Success {
         switch self {
-        case .value(let value):
+        case .success(let value):
             return value
-        case .error(let error):
+        case .failure(let error):
             throw error
         }
     }
 }
 
-extension Result where Error == Swift.Error {
+extension Result where Failure == Error {
     /// Create an instance by capturing the output of a throwing closure.
     ///
     /// - Parameter throwing: A throwing closure to evaluate.
     @_transparent
-    public init(catching body: () throws -> Value) {
+    public init(catching body: () throws -> Success) {
         do {
-            self = .value(try body())
+            self = .success(try body())
         } catch let error {
-            self = .error(error)
+            self = .failure(error)
         }
     }
 }
 
-extension Result : Equatable where Value : Equatable, Error : Equatable { }
+extension Result : Equatable where Success : Equatable, Failure : Equatable { }
 
-extension Result : Hashable where Value : Hashable, Error : Hashable { }
+extension Result : Hashable where Success : Hashable, Failure : Hashable { }

--- a/Sources/SwiftResult/Result.swift
+++ b/Sources/SwiftResult/Result.swift
@@ -1,10 +1,10 @@
 /// A value that represents either a success or failure, capturing associated
 /// values in both cases.
 public enum Result<Success, Failure/*: Error*/> {
-    /// A normal result, storing a `Value`.
+    /// A normal result, storing a `Success`.
     case success(Success)
     
-    /// An error result, storing an `Error`.
+    /// An error result, storing an `Failure`.
     case failure(Failure)
     
     /// Evaluates the given transform closure when this `Result` instance is

--- a/SwiftResult.xcodeproj/project.pbxproj
+++ b/SwiftResult.xcodeproj/project.pbxproj
@@ -21,6 +21,9 @@
 		D628438321AFB1B4000555D0 /* SwiftResultTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D628437F21AFB1B4000555D0 /* SwiftResultTests.swift */; };
 		D628438421AFB1B4000555D0 /* SwiftResultTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D628437F21AFB1B4000555D0 /* SwiftResultTests.swift */; };
 		D628438521AFB1B4000555D0 /* SwiftResultTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D628437F21AFB1B4000555D0 /* SwiftResultTests.swift */; };
+		D6DA4C4D21BDDA23002CC684 /* JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6DA4C4C21BDDA23002CC684 /* JSON.swift */; };
+		D6DA4C4E21BDDA23002CC684 /* JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6DA4C4C21BDDA23002CC684 /* JSON.swift */; };
+		D6DA4C4F21BDDA23002CC684 /* JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6DA4C4C21BDDA23002CC684 /* JSON.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -60,6 +63,7 @@
 		D628437021AFB1A5000555D0 /* SwiftResult.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SwiftResult.h; sourceTree = "<group>"; };
 		D628437F21AFB1B4000555D0 /* SwiftResultTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftResultTests.swift; sourceTree = "<group>"; };
 		D628438121AFB1B4000555D0 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		D6DA4C4C21BDDA23002CC684 /* JSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSON.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -171,6 +175,7 @@
 			isa = PBXGroup;
 			children = (
 				D628437F21AFB1B4000555D0 /* SwiftResultTests.swift */,
+				D6DA4C4C21BDDA23002CC684 /* JSON.swift */,
 				D628438121AFB1B4000555D0 /* Info.plist */,
 			);
 			path = SwiftResultTests;
@@ -462,6 +467,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D628438321AFB1B4000555D0 /* SwiftResultTests.swift in Sources */,
+				D6DA4C4D21BDDA23002CC684 /* JSON.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -478,6 +484,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D628438421AFB1B4000555D0 /* SwiftResultTests.swift in Sources */,
+				D6DA4C4E21BDDA23002CC684 /* JSON.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -494,6 +501,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D628438521AFB1B4000555D0 /* SwiftResultTests.swift in Sources */,
+				D6DA4C4F21BDDA23002CC684 /* JSON.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Tests/SwiftResultTests/JSON.swift
+++ b/Tests/SwiftResultTests/JSON.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+enum JSON {
+    indirect case object([String: JSON])
+    indirect case array([JSON])
+    case number(Double)
+    case string(String)
+    case boolean(Bool)
+    case null
+}
+
+extension JSON {
+    func jsonObject() -> Any {
+        switch self {
+        case .object(let object):
+            var jsonObject: [String: Any] = [:]
+            for (key, value) in object {
+                jsonObject[key] = value.jsonObject()
+            }
+            return jsonObject
+        case .array(let array):
+            return array.map { $0.jsonObject() }
+        case .number(let number):
+            return number
+        case .string(let string):
+            return string
+        case .boolean(let boolean):
+            return boolean
+        case .null:
+            return NSNull()
+        }
+    }
+    
+    func data(options: JSONSerialization.WritingOptions = []) -> Data {
+        let jsonObject = self.jsonObject()
+        assert(JSONSerialization.isValidJSONObject(jsonObject))
+        return try! JSONSerialization.data(withJSONObject: jsonObject, options: options)
+    }
+}

--- a/Tests/SwiftResultTests/SwiftResultTests.swift
+++ b/Tests/SwiftResultTests/SwiftResultTests.swift
@@ -105,15 +105,13 @@ final class SwiftResultTests: XCTestCase {
     }
     
     func testExample() {
-        let json = """
-        {
-            "firstName": "Albert",
-            "lastName": "Einstein",
-            "age": 28
-        }
-        """
+        let json: JSON = .object([
+            "firstName": .string("Albert"),
+            "lastName": .string("Einstein"),
+            "age": .number(28),
+        ])
         
-        let person: Result<Person, DecodingError> = JSONDecoder().decode(Person.self, from: json.data(using: .utf8)!)
+        let person: Result<Person, DecodingError> = JSONDecoder().decode(Person.self, from: json)
         
         switch person {
         case .success(let person):
@@ -144,9 +142,9 @@ struct Person: Codable {
 }
 
 extension JSONDecoder {
-    func decode<T: Decodable>(_ type: T.Type, from data: Data) -> Result<T, DecodingError> {
+    func decode<T: Decodable>(_ type: T.Type, from json: JSON) -> Result<T, DecodingError> {
         do {
-            return .success(try self.decode(T.self, from: data))
+            return .success(try self.decode(T.self, from: json.data()))
         } catch let error as DecodingError {
             return .failure(error)
         } catch _ {


### PR DESCRIPTION
- Rename `Value` to `Success`
- Rename `Error` to `Failure`
- Rename `value` to `success`
- Rename `error` to `failure`
- Rename `unwrapped` to `get`
